### PR TITLE
Replace json encoder: encoding/json -> github.com/goccy/go-json

### DIFF
--- a/render.go
+++ b/render.go
@@ -1,15 +1,16 @@
 package go_ssr
 
 import (
-	"encoding/json"
 	"fmt"
-	"github.com/natewong1313/go-react-ssr/internal/html"
-	"github.com/natewong1313/go-react-ssr/internal/utils"
-	"github.com/rs/zerolog"
 	"html/template"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/goccy/go-json"
+	"github.com/natewong1313/go-react-ssr/internal/html"
+	"github.com/natewong1313/go-react-ssr/internal/utils"
+	"github.com/rs/zerolog"
 )
 
 // RenderConfig is the config for rendering a route


### PR DESCRIPTION
The default `encoding/json` package is too slow, the response time on web and `engine.RenderRoute` execution is about 2.x faster using `goccy/go-json`
